### PR TITLE
Corrects Weird .value issue

### DIFF
--- a/lib/Method/Also.pm6
+++ b/lib/Method/Also.pm6
@@ -8,8 +8,7 @@ module Method::Also:ver<0.0.3>:auth<cpan:ELIZABETH> {
 
         method compose (Mu \o, :$compiler_services) is hidden-from-backtrace {
           for %aliases{o.^name}[] {
-            next unless $_;
-            o.^add_method(.key, .value);
+            o.^add_method(.key, .value) if $_;
           }
           nextsame;
         }

--- a/lib/Method/Also.pm6
+++ b/lib/Method/Also.pm6
@@ -7,8 +7,11 @@ module Method::Also:ver<0.0.3>:auth<cpan:ELIZABETH> {
     role AliasableClassHOW {
 
         method compose (Mu \o, :$compiler_services) is hidden-from-backtrace {
-            o.^add_method(.key, .value) for %aliases{o.^name}[];
-            nextsame;
+          for %aliases{o.^name}[] {
+            next unless $_;
+            o.^add_method(.key, .value);
+          }
+          nextsame;
         }
 
     }
@@ -18,13 +21,14 @@ module Method::Also:ver<0.0.3>:auth<cpan:ELIZABETH> {
         method specialize(Mu \r, Mu:U \obj, *@pos_args, *%named_args)
             is hidden-from-backtrace
         {
-
             obj.HOW does AliasableClassHOW unless obj.HOW ~~ AliasableClassHOW;
 
             my $*TYPE-ENV;
             my $r := callsame;
             unless %aliases-composed{r.^name} {
                 for %aliases{r.^name}[] -> $p {
+                    # cw: This should never happen, but somehow it is... 
+                    next unless $p;
                     next unless $p.value.is_dispatcher;
 
                     obj.^add_method($p.key, $p.value);


### PR DESCRIPTION
- Should fix issues where an compile complains about a .value and the line given is the start of a role or class definition.

Take the following role definition:

```
role Pango::Roles::References {
  has Pointer $!ref;

  # We use these for inc/dec ops
  method upref
    is also<ref>
  {
    g_object_ref($!ref);
    self;
  }
  method downref
    is also<unref>
  { g_object_unref($!ref); }
}
```

If I compile this using the existing Method::Also, I get the following error:

```
===SORRY!=== Error while compiling /home/cbwood/Projects/p6-Pango/lib/Pango/Context.pm6 (Pango::Context)
    No such method 'value' for invocant of type 'Any'. Did you mean 'values'?
    at /home/cbwood/Projects/p6-Pango/lib/Pango/Context.pm6 (Pango::Context):15
```

This PR seems to mute...and hopefully correct... this error.