### PR TITLE
Make sure method `handles` trait is not re-applied

### DIFF
--- a/lib/Method/Also.rakumod
+++ b/lib/Method/Also.rakumod
@@ -5,7 +5,7 @@ my role AliasableClassHOW {
 
     method compose (Mu \o, :$compiler_services) is hidden-from-backtrace {
       for %aliases{o.^name}[] {
-        o.^add_method(.key, .value) if $_;
+        o.^add_method(.key, .value, :!handles) if $_;
       }
       nextsame;
     }
@@ -27,7 +27,7 @@ my role AliasableRoleHOW {
                 next unless $p;
                 next unless $p.value.is_dispatcher;
 
-                obj.^add_method($p.key, $p.value);
+                obj.^add_method($p.key, $p.value, :!handles);
                 for r.^multi_methods_to_incorporate {
                     obj.^add_multi_method(
                         $p.key,

--- a/lib/Method/Also.rakumod
+++ b/lib/Method/Also.rakumod
@@ -1,11 +1,13 @@
 my %aliases;
 my %aliases-composed;
 
+constant %no_handles = $*RAKU.compiler.version >= v2022.06.60.ga.7.e.9.b.1938 ?? :!handles !! Empty;
+
 my role AliasableClassHOW {
 
     method compose (Mu \o, :$compiler_services) is hidden-from-backtrace {
       for %aliases{o.^name}[] {
-        o.^add_method(.key, .value, :!handles) if $_;
+        o.^add_method(.key, .value, |%no_handles) if $_;
       }
       nextsame;
     }
@@ -27,7 +29,7 @@ my role AliasableRoleHOW {
                 next unless $p;
                 next unless $p.value.is_dispatcher;
 
-                obj.^add_method($p.key, $p.value, :!handles);
+                obj.^add_method($p.key, $p.value, |%no_handles);
                 for r.^multi_methods_to_incorporate {
                     obj.^add_multi_method(
                         $p.key,


### PR DESCRIPTION
rakudo/rakudo#4994 resulted in an unpleased issue where duplicating the
same method object under a different name caused lazy `handles`
application to be repeated and delegation methods re-added again. For
now I have added a check which prevents this to happen if the method
duplication is detected, but it's an additional loop iterating over
already installed ones.

To fix this issue I have added `:$handles` parameter to `add_method`.
Currently it would serve as a mere optimization if negated. But in the
future (likely after this commit makes it into `Method::Also` release)
I plan to remove the loop and make any third party module to make sure
they don't cause delegation duplication.